### PR TITLE
Add experimental REST API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,39 @@ All features can be enabled or disabled through the build-time configuration ([`
 * CLI utilities (`xdpfw-add`, `xdpfw-del`) enable **dynamic rule** management without restarting the firewall.
 * Supports integration with **user-space security systems** for enhanced protection.
 
+### 🌐 REST API (Experimental)
+* Provides a simple Flask-based service in `api/xdpfw_api.py`.
+* Exposes endpoints to add or remove filter rules using the existing CLI tools.
+* Start the API with:
+
+```bash
+pip install flask
+python3 api/xdpfw_api.py
+```
+
+Once running, the server listens on `http://localhost:8080/`.
+
+#### Endpoints
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `POST` | `/filters` | Add a rule using the same flags as `xdpfw-add` in JSON form. |
+| `DELETE` | `/filters/<idx>` | Remove the rule with the given index via `xdpfw-del`. |
+
+Example request to add a rule:
+
+```bash
+curl -X POST http://localhost:8080/filters \
+     -H "Content-Type: application/json" \
+     -d '{"enabled": true, "log": true, "action": 0, "sip": "10.0.0.1"}'
+```
+
+To delete rule index 0:
+
+```bash
+curl -X DELETE http://localhost:8080/filters/0
+```
+
 ## 🛠️ Building & Installing
 Before building, ensure the following packages are installed. These packages can be installed with `apt` on Debian-based systems (e.g. Ubuntu, etc.), but there should be similar names in other package managers.
 

--- a/api/xdpfw_api.py
+++ b/api/xdpfw_api.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Simple REST API for managing XDP Firewall rules.
+
+This script exposes minimal endpoints for adding and deleting
+filter rules using the existing ``xdpfw-add`` and ``xdpfw-del``
+CLI utilities.
+
+Dependencies: ``Flask``. Install via ``pip install flask``.
+"""
+
+from flask import Flask, request, jsonify
+import subprocess
+import shutil
+
+app = Flask(__name__)
+
+ADD_BIN = shutil.which("xdpfw-add") or "/usr/bin/xdpfw-add"
+DEL_BIN = shutil.which("xdpfw-del") or "/usr/bin/xdpfw-del"
+
+
+def run_cmd(cmd):
+    """Execute command and capture output."""
+    proc = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+@app.route("/filters", methods=["POST"])
+def add_filter():
+    """Add a filter rule via ``xdpfw-add``."""
+    data = request.get_json(force=True) or {}
+    args = []
+    for key, value in data.items():
+        if isinstance(value, bool):
+            value = int(value)
+        args.append(f"--{key.replace('_', '-')}={value}")
+
+    cmd = f"{ADD_BIN} " + " ".join(args)
+    rc, out, err = run_cmd(cmd)
+    if rc != 0:
+        return jsonify({"error": err.strip()}), 400
+    return jsonify({"result": out.strip()})
+
+
+@app.route("/filters/<int:idx>", methods=["DELETE"])
+def delete_filter(idx):
+    """Delete a filter rule via ``xdpfw-del``."""
+    cmd = f"{DEL_BIN} --idx={idx}"
+    rc, out, err = run_cmd(cmd)
+    if rc != 0:
+        return jsonify({"error": err.strip()}), 400
+    return jsonify({"result": out.strip()})
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8080)


### PR DESCRIPTION
## Summary
- add a minimal Flask-based REST API to manage firewall rules
- document the REST API in README
- expand usage section with endpoint examples

## Testing
- `python3 -m py_compile api/xdpfw_api.py`
- `make -n loader`

------
https://chatgpt.com/codex/tasks/task_e_6875cf599260832a92b64a52fa387823