### PR TITLE
Add SQLite stats storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ All features can be enabled or disabled through the build-time configuration ([`
 ### 🌐 REST API (Experimental)
 
 * Lightweight C service built with [Mongoose](https://github.com/cesanta/mongoose) in `api/xdpfw_api.c`.
-* Stores created rules and attack logs in a small SQLite database located at `/var/lib/xdpfw/filters.db` (override with `XDPFW_STATS_DB`). The `xdpfw` loader automatically logs filtered packets to this database and the API reloads rules at startup.
+* Stores created rules, attack logs, and packet counters in a small SQLite database located at `/var/lib/xdpfw/filters.db` (override with `XDPFW_STATS_DB`). The `xdpfw` loader automatically logs filtered packets and periodic statistics to this database and the API reloads rules at startup.
 * Exposes endpoints to create, update, list and delete dynamic filter rules through the existing CLI utilities.
 * Uses a simple **Bearer token** for authentication. Set `XDPFW_API_TOKEN` before starting the service.
 * Includes a `systemd` unit file `other/xdpfw-api.service` for running the server as a daemon.

--- a/src/loader/prog.c
+++ b/src/loader/prog.c
@@ -492,6 +492,8 @@ int main(int argc, char *argv[])
             {
                 log_msg(&cfg, 1, 0, "[WARNING] Failed to calculate packet stats. Stats map FD => %d...\n", map_stats);
             }
+
+            save_stats_db(get_log_db(), map_stats, cpus);
         }
 
 #if defined(ENABLE_FILTERS) && defined(ENABLE_FILTER_LOGGING)

--- a/src/loader/utils/logging.c
+++ b/src/loader/utils/logging.c
@@ -18,6 +18,8 @@ int init_log_db(const char* path)
     }
     const char* sql = "CREATE TABLE IF NOT EXISTS logs (ts INTEGER, src_ip TEXT, dst_ip TEXT, protocol INTEGER, bps INTEGER, len INTEGER, status TEXT, block_time INTEGER)";
     sqlite3_exec(log_db, sql, NULL, NULL, NULL);
+    const char* sql2 = "CREATE TABLE IF NOT EXISTS stats (ts INTEGER, allowed INTEGER, dropped INTEGER, passed INTEGER)";
+    sqlite3_exec(log_db, sql2, NULL, NULL, NULL);
     return 0;
 }
 
@@ -28,6 +30,11 @@ void close_log_db(void)
         sqlite3_close(log_db);
         log_db = NULL;
     }
+}
+
+sqlite3* get_log_db(void)
+{
+    return log_db;
 }
 
 /**

--- a/src/loader/utils/logging.h
+++ b/src/loader/utils/logging.h
@@ -5,6 +5,7 @@
 #include <stdio.h>
 
 #include <time.h>
+#include <sqlite3.h>
 
 #include <common/all.h>
 
@@ -23,3 +24,4 @@ int hdl_filters_rb_event(void* ctx, void* data, size_t sz);
 
 int init_log_db(const char* path);
 void close_log_db(void);
+sqlite3* get_log_db(void);

--- a/src/loader/utils/stats.h
+++ b/src/loader/utils/stats.h
@@ -8,5 +8,7 @@
 #include <loader/utils/helpers.h>
 
 #include <time.h>
+#include <sqlite3.h>
 
 int calc_stats(int map_stats, int cpus, int per_second);
+int save_stats_db(sqlite3* db, int map_stats, int cpus);


### PR DESCRIPTION
## Summary
- log packet counters to `stats` table in SQLite database
- expose `get_log_db` helper
- save stats from main loop via new helper
- document new stats table

## Testing
- `apt-get install -y libconfig-dev libsqlite3-dev`
- `make` *(fails: 'xdp/libxdp.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68785274bcf48332ac8f62da58ca28c1